### PR TITLE
Allow better ticket channel name customisation

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -111,7 +111,7 @@ TicketCategories:
     embedTitle: "Report Ticket" # The title of the embed
     color: "#FFD700" # The color of embed in the opened ticket
     description: "Welcome {user} ({user.tag}) to your report ticket! Please be patient while a staff member responds to your report." # The description of the embed in the created ticket, right above the questions fields, use {user} for the user such as @User and {user.tag} for the name of the user without it being mentioned such as User
-    ticketName: "TICKETCOUNT" # Options are: USERNAME (will be called name-USERNAME such as report-ralphkb), TICKETCOUNT (will be called name-TICKETCOUNT such as "report-12348") or BOTH (will be called USERNAME-TICKETCOUNT such as "ralphkb-12348")
+    ticketName: "DEFAULT" Options are: CATEGORY-USERNAME (will be called category-USERNAME such as general-ralphkb), CATEGORY-TICKETCOUNT (will be called category-TICKETCOUNT such as general-12348), USERNAME-TICKETCOUNT (will be called USERNAME-TICKETCOUNT such as ralphkb-12348), USERNAME-CATEGORY (will be called USERNAME-category such as ralphkb-general), USERNAME-CATEGORY-TICKETCOUNT (will be called USERNAME-category-TICKETCOUNT such as ralphkb-general-12348), or DEFAULT (will be called category-USERNAME-TICKETCOUNT such as general-ralphkb-12348)
     ticketTopic: "Ticket Creator: {user} | Ticket Type: {type}" # The topic of the ticket channel
     slowmode: "0" # The slowmode of the ticket channel in seconds, keep it 0 if you don't want a slowmode and do not use negative values
     useCodeBlocks: false # Set this to true if you want to use code blocks to display the answers of the ticket category questions
@@ -182,7 +182,7 @@ TicketCategories:
     embedTitle: "Other Ticket" # The title of the embed
     color: "#ADD8E6" # The color of embed in the opened ticket
     description: "Welcome {user} ({user.tag}) to your other ticket! Please be patient while a staff member responds to your questions." # The description of the embed in the created ticket, right above the questions fields, use {user} for the user such as @User and {user.tag} for the name of the user without it being mentioned such as User
-    ticketName: "USERNAME" # Options are: USERNAME (will be called name-USERNAME such as other-ralphkb), TICKETCOUNT (will be called name-TICKETCOUNT such as "other-12348") or BOTH (will be called USERNAME-TICKETCOUNT such as "ralphkb-12348")
+    ticketName: "DEFAULT" Options are: CATEGORY-USERNAME (will be called category-USERNAME such as general-ralphkb), CATEGORY-TICKETCOUNT (will be called category-TICKETCOUNT such as general-12348), USERNAME-TICKETCOUNT (will be called USERNAME-TICKETCOUNT such as ralphkb-12348), USERNAME-CATEGORY (will be called USERNAME-category such as ralphkb-general), USERNAME-CATEGORY-TICKETCOUNT (will be called USERNAME-category-TICKETCOUNT such as ralphkb-general-12348), or DEFAULT (will be called category-USERNAME-TICKETCOUNT such as general-ralphkb-12348)
     ticketTopic: "Ticket Creator: {user} | Ticket Type: {type}" # The topic of the ticket channel
     slowmode: "0" # The slowmode of the ticket channel in seconds, keep it 0 if you don't want a slowmode and do not use negative values
     useCodeBlocks: false # Set this to true if you want to use code blocks to display the answers of the ticket category questions

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -1636,14 +1636,23 @@ module.exports = {
 
             let channelName;
             switch (configValue) {
-              case "USERNAME":
-                channelName = `${category.name}-${USERNAME}`;
+              case "CATEGORY-USERNAME":
+                    channelName = `${category.name}-${USERNAME}`;
                 break;
-              case "TICKETCOUNT":
-                channelName = `${category.name}-${TICKETCOUNT}`;
+              case "CATEGORY-TICKETCOUNT":
+                    channelName = `${category.name}-${TICKETCOUNT}`;
                 break;
-              case "BOTH":
-                channelName = `${USERNAME}-${TICKETCOUNT}`;
+              case "USERNAME-TICKETCOUNT":
+                    channelName = `${USERNAME}-${TICKETCOUNT}`;
+                break;
+              case "USERNAME-CATEGORY":
+                    channelName = `${USERNAME}-${category.name}`;
+                break;
+              case "USERNAME-CATEGORY-TICKETCOUNT":
+                    channelName = `${USERNAME}-${category.name}-${TICKETCOUNT}`;
+                break;
+              case "DEFAULT":
+                    channelName = `${category.name}-${USERNAME}-${TICKETCOUNT}`;
                 break;
               default:
                 throw new Error(


### PR DESCRIPTION
Pretty self-explanatory but here are the new options 

- ``CATEGORY-USERNAME`` (will be called category-USERNAME such as general-ralphkb)
- ``CATEGORY-TICKETCOUNT`` (will be called category-TICKETCOUNT such as general-12348)
- ``USERNAME-TICKETCOUNT`` (will be called USERNAME-TICKETCOUNT such as ralphkb-12348)
- ``USERNAME-CATEGORY`` (will be called USERNAME-category such as ralphkb-general)
- ``USERNAME-CATEGORY-TICKETCOUNT`` (will be called USERNAME-category-TICKETCOUNT such as ralphkb-general-12348)
- ``DEFAULT`` (will be called category-USERNAME-TICKETCOUNT such as general-ralphkb-12348)

Let me know if you like any changes. I understand this might not get implemented as it'll break the config when existing user upgrade, but, most likely they'll adapt to this and it'll help new users have a better customisation of the ticket channel name as when I started using the bot, I had to manually add these options.
